### PR TITLE
Add Dockerfile, CI workflow, and parse Gemini response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use official Node.js runtime as the base image
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Expose port
+EXPOSE 3000
+
+# Start the server
+CMD ["npm", "start"]

--- a/src/routes/create.ts
+++ b/src/routes/create.ts
@@ -1,5 +1,17 @@
-// Map LLM output to schema-compliant assessment
+// Map LLM output (raw Gemini or already-parsed) to schema-compliant assessment
 function mapLLMToSchema(llm: any): any {
+  // If the response is the full Gemini API payload, extract the text then parse
+  if (llm?.candidates) {
+    const text = llm.candidates?.[0]?.content?.parts
+      ?.map((p: any) => p.text ?? "")
+      .join("") ?? "";
+    try {
+      llm = JSON.parse(safeJSONCut(text));
+    } catch {
+      llm = {};
+    }
+  }
+
   const mcqs = (llm.mcqs || []).map((q: any, idx: number) => ({
     id: q.id || String(idx + 1),
     prompt: q.question || q.prompt || '',
@@ -40,7 +52,7 @@ import { CreateTestReq, CreateTestRes } from "../schemas/create";
 import { extractSkills, inferLevel } from "../lib/parse";
 import { generatePrompt } from "../lib/prompts";
 import { llmJSON } from "../providers";
-import { dedupeMCQByPrompt, ensureCoverageDBAPI } from "../lib/utils";
+import { dedupeMCQByPrompt, ensureCoverageDBAPI, safeJSONCut } from "../lib/utils";
 import { Assessment, TAssessment } from "../schemas/common";
 
 type Level = "fresher" | "junior" | "mid" | "senior";


### PR DESCRIPTION
## Summary
- containerize Node server with Node 20 image, installing dependencies via npm ci and building before runtime
- add GitHub Actions workflow running npm ci and npm test for push and PR events
- handle raw Gemini API responses by parsing candidate text into the assessment schema

## Testing
- `npm test` *(fails: Cannot find module 'express' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c77bb2d36083329368c3b6032e2c85