### PR TITLE
feat: add google generative ai node script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # demogoogleapi
+
+Simple Node.js script that sends a prompt to Google's Generative AI API and prints the text response.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+   If installation fails, ensure network access to npm registry.
+
+2. Set your API key:
+   ```bash
+   export GOOGLE_API_KEY="your_key_here"
+   ```
+
+## Usage
+
+Run with a prompt:
+```bash
+node index.js "Tell me a joke"
+```
+The model's reply will be printed as plain text.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+const { GoogleGenerativeAI } = require('@google/generative-ai');
+
+const apiKey = process.env.GOOGLE_API_KEY;
+if (!apiKey) {
+  console.error('Missing GOOGLE_API_KEY environment variable');
+  process.exit(1);
+}
+
+const prompt = process.argv.slice(2).join(' ').trim();
+if (!prompt) {
+  console.error('Usage: node index.js <prompt>');
+  process.exit(1);
+}
+
+async function run() {
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text();
+    console.log(text);
+  } catch (err) {
+    console.error('Error generating content:', err.message);
+    process.exit(1);
+  }
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "demogoogleapi",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@google/generative-ai": "^0.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `index.js` to send prompts to Google's Generative AI and print text responses
- document setup and usage in `README.md`
- track `@google/generative-ai` dependency in `package.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a094a3a083328ce62f03f0dd4f3e